### PR TITLE
feat: add custom rounded button

### DIFF
--- a/client/app/src/main/res/drawable/default_button.xml
+++ b/client/app/src/main/res/drawable/default_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/default_button" />
+    <corners android:radius="100dp" />
+</shape>

--- a/client/app/src/main/res/drawable/disabled_button.xml
+++ b/client/app/src/main/res/drawable/disabled_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/disabled_button" />
+    <corners android:radius="100dp" />
+</shape>

--- a/client/app/src/main/res/drawable/focused_button.xml
+++ b/client/app/src/main/res/drawable/focused_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/focused_button" />
+    <corners android:radius="100dp" />
+</shape>

--- a/client/app/src/main/res/drawable/pressed_button.xml
+++ b/client/app/src/main/res/drawable/pressed_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/pressed_button" />
+    <corners android:radius="100dp" />
+</shape>

--- a/client/app/src/main/res/drawable/rounded_button.xml
+++ b/client/app/src/main/res/drawable/rounded_button.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/pressed_button"
+        android:state_pressed="true" />
+    <item
+        android:drawable="@drawable/focused_button"
+        android:state_focused="true" />
+    <item
+        android:drawable="@color/disabled_button"
+        android:state_enabled="false" />
+    <item
+        android:drawable="@drawable/default_button"
+        android:state_enabled="true" />
+</selector>

--- a/client/app/src/main/res/values/colors.xml
+++ b/client/app/src/main/res/values/colors.xml
@@ -3,4 +3,10 @@
     <color name="colorPrimary">#6200EE</color>
     <color name="colorPrimaryDark">#3700B3</color>
     <color name="colorAccent">#03DAC5</color>
+
+    <!--  Button Colors  -->
+    <color name="default_button">#94fc03</color>
+    <color name="focused_button">#76c408</color>
+    <color name="disabled_button">#c6f584</color>
+    <color name="pressed_button">#77a13b</color>
 </resources>


### PR DESCRIPTION
# Description of Changes
Added a new custom rounded button.
This button contains 4 states:
- Default [The default appearance]
- Pressed [When the user presses the button]
- Disabled [If the button is disabled]
- Focused [If the user highlights the button- this can be done through pressing tab on a computer for example]
Each button is associated with a color which can be manipulated from the `color` folder. I've set it to a default green color.

## How to Use the Button in your Activities
If you want to use this template for your buttons, simply include the following line into your button's xml tag.
`android:background="@drawable/rounded_button"`

## How to Change the Button Colors:
Navigate to `app/res/values/colors` and modify the appropriate color tag.

## Example of button in use:
![image](https://user-images.githubusercontent.com/45128157/96794345-41e0dd80-13bb-11eb-8511-96445148d76a.png)
