### PR TITLE
fix: back button is fixed for MyBooks

### DIFF
--- a/client/app/src/main/java/com/example/criengine/Activities/MyBooksActivity.java
+++ b/client/app/src/main/java/com/example/criengine/Activities/MyBooksActivity.java
@@ -132,4 +132,13 @@ public class MyBooksActivity extends AppCompatActivity implements FilterFragment
         }
         myBooksListAdapter.notifyDataSetChanged();
     }
+
+    /**
+     * Overrides the back button so it returns to the main activity.
+     */
+    @Override
+    public void onBackPressed() {
+        Intent intent = new Intent(this, MainActivity.class);
+        startActivity(intent);
+    }
 }

--- a/client/app/src/main/java/com/example/criengine/Objects/Profile.java
+++ b/client/app/src/main/java/com/example/criengine/Objects/Profile.java
@@ -256,6 +256,10 @@ public class Profile {
         notifications.add(notif);
     }
 
+    /**
+     * Remove a notification from the list.
+     * @param notif The notification to remove.
+     */
     public void removeNotification(Notification notif) {
         notifications.remove(notif);
     }

--- a/client/app/src/test/java/com/example/criengine/ProfileUnitTest.java
+++ b/client/app/src/test/java/com/example/criengine/ProfileUnitTest.java
@@ -1,5 +1,6 @@
 package com.example.criengine;
 
+import com.example.criengine.Objects.Notification;
 import com.example.criengine.Objects.Profile;
 
 import org.junit.Before;
@@ -32,6 +33,7 @@ public class ProfileUnitTest {
         assertNull(mock.getBio());
         assertEquals(mock.getBooksOwned().size(), 0);
         assertEquals(mock.getBooksBorrowedOrRequested().size(), 0);
+        assertEquals(mock.getNotifications().size(), 0);
     }
 
     @Test
@@ -47,6 +49,7 @@ public class ProfileUnitTest {
         assertEquals(mock.getBio(), "Bio");
         assertEquals(mock.getBooksOwned().size(), 0);
         assertEquals(mock.getBooksBorrowedOrRequested().size(), 0);
+        assertEquals(mock.getNotifications().size(), 0);
     }
 
     @Test
@@ -62,6 +65,7 @@ public class ProfileUnitTest {
         assertNull(mock.getBio());
         assertEquals(mock.getBooksOwned().size(), 0);
         assertEquals(mock.getBooksBorrowedOrRequested().size(), 0);
+        assertEquals(mock.getNotifications().size(), 0);
     }
 
     @Test
@@ -132,5 +136,21 @@ public class ProfileUnitTest {
         newBorrowedOrRequested.add("A new book!");
         mock.setBooksBorrowedOrRequested(newBorrowedOrRequested);
         assertEquals(mock.getBooksBorrowedOrRequested().get(0), "A new book!");
+    }
+
+    @Test
+    public void testNotificationMethods() {
+        Notification mockNotification = new Notification("Mock notification.");
+        mock.addNotification(mockNotification);
+        assertEquals(mock.getNotifications().get(0).getDescription(), "Mock notification.");
+
+        mock.removeNotification(mockNotification);
+        assertEquals(mock.getNotifications().size(), 0);
+
+        ArrayList<Notification> newMockNotificationList = new ArrayList<>();
+        Notification anotherMockNotification = new Notification("Another mock notification.");
+        newMockNotificationList.add(anotherMockNotification);
+        mock.setNotifications(newMockNotificationList);
+        assertEquals(mock.getNotifications().get(0).getDescription(), "Another mock notification.");
     }
 }


### PR DESCRIPTION
## Pull Request Description
#### Summary of changes/features added:
- So whenever you were on MyBooks and navigated to Add a book activity or view requests activity and then returned to MyBooks. The back button would return to the previous screen rather than the MainActivity. (it looked really weird). This should fix it.
- Also added some javadocs and tests


#### Link to referenced github issue: 
N/A

## Pull Request Checklist
- [x] Unit test written?
- [ ] (**For later in project**) Integration tests written?
- [x] Java docs written?
