### PR TITLE
fix: clicking a book in the list will not break

### DIFF
--- a/client/app/src/main/java/com/example/criengine/Adapters/MyBooksAdapter.java
+++ b/client/app/src/main/java/com/example/criengine/Adapters/MyBooksAdapter.java
@@ -10,6 +10,8 @@ import android.widget.Button;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.example.criengine.Activities.MyBookActivity;
 import com.example.criengine.Activities.RequestsForBookActivity;
 import com.example.criengine.Objects.Book;
 import com.example.criengine.R;
@@ -61,6 +63,16 @@ public class MyBooksAdapter extends ArrayAdapter<Book> {
 
         // Get the book to be displayed.
         final Book book = bookItems.get(position);
+
+        // Opens to the book information screen when you click on a specific book.
+        view.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(v.getContext(), MyBookActivity.class);
+                intent.putExtra("Book", book);
+                v.getContext().startActivity(intent);
+            }
+        });
 
         // Set the text for the header and status.
         headerText.setText(book.getTitle());

--- a/client/app/src/main/java/com/example/criengine/Fragments/MyBooksListFilterFragment.java
+++ b/client/app/src/main/java/com/example/criengine/Fragments/MyBooksListFilterFragment.java
@@ -52,7 +52,7 @@ public class MyBooksListFilterFragment extends DialogFragment implements Seriali
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-            listener = (MyBooksListFragment) getParentFragment();
+        listener = (MyBooksListFragment) getParentFragment();
     }
 
     /**

--- a/client/app/src/main/java/com/example/criengine/Fragments/MyBooksListFragment.java
+++ b/client/app/src/main/java/com/example/criengine/Fragments/MyBooksListFragment.java
@@ -81,16 +81,6 @@ public class MyBooksListFragment extends RootFragment implements MyBooksListFilt
                 }
         );
 
-        // Opens to the book information screen when you click on a specific book.
-        headerText.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                Intent intent = new Intent(view.getContext(), MyBookActivity.class);
-                intent.putExtra("Book", displayBooks.get(position));
-                view.getContext().startActivity(intent);
-            }
-        });
-
         // Opens to the add-a-book screen when you click the button.
         addBookButton = getView().findViewById(R.id.add_a_book);
         addBookButton.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
## Pull Request Description
#### Summary of changes/features added:
- Originally, when you would swipe to different screens, the navigating back to the book list screen, you would not be able to click a book to open up to a detailed information screen. Its fixed now

#### Screenshots of UI changes (update with each new commit): 
- 

#### Link to referenced github issue: 

## Pull Request Checklist
- [ ] Unit test written?
- [ ] (**For later in project**) Integration tests written?
- [x] Java docs written?
